### PR TITLE
Rename to `model-service`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM julia:1.8.1
 
-ADD src /model-transform
+ADD src /model-service
 
 # Pre-install Catlab related dependencies
 RUN julia -e 'import Pkg; Pkg.update()' && \
@@ -12,4 +12,4 @@ RUN julia -e 'import Pkg; Pkg.update()' && \
     julia -e 'import Pkg; Pkg.add("Genie"); using Genie' && \
     julia -e 'import Pkg; Pkg.add("JSON"); using JSON'
 
-CMD julia model-transform/service.jl
+CMD julia model-service/service.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "model-transform"
+name = "model-service"
 uuid = "47decf57-f457-4d18-8951-196ff91e04e6"
 authors = ["dchang <dchang@uncharted.software>"]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# Model Transform
-This is a webservice that provies a REST-API wrappers around [Catlab.jl](https://github.com/AlgebraicJulia/Catlab.jl). 
+# Model Service
+This is a webservice that provies a REST-API wrappers around Julia and [Catlab.jl](https://github.com/AlgebraicJulia/Catlab.jl). 
 
 
 ## Docker image
 The Dockerfile provides a runnable web-service
 
 ```
-docker build . -t askem-model-transform
+$ docker build . -t askem-model-service
+$ docker run -p 8888:8888 askem-model-service
 ```


### PR DESCRIPTION
This repository is starting to include more than just transformation.
To avoid confusion and keep thing simple, the repository has been renamed `model-service`.

This PR reflect this change within the codebase.