### PR TITLE
feat: model composition

### DIFF
--- a/src/service.jl
+++ b/src/service.jl
@@ -315,8 +315,14 @@ route("/api/models/:model_id/model-composition", method = POST) do
     modelB = data["modelB"]
     commonStates = data["commonStates"]
 
+    # Check for invalid input
+
     # Find ID of names based on order
-    IDsToMerge = fill(Dict{String, Int64}("modelA" => 0, "modelB" => 0), length(commonStates))
+    IDsToMerge = []
+    for i in 1:length(commonStates)
+        push!(IDsToMerge, Dict{String, Int64}("modelA" => 0, "modelB" => 0))
+    end
+    
     IDsToMergeB = [] # Use for merging inputs and outputs later
 
     # Find common state ids
@@ -334,8 +340,6 @@ route("/api/models/:model_id/model-composition", method = POST) do
         end
     end
 
-    println(IDsToMerge)
-
     # Will represent the merged petrinet, make a copy of modelA and add on to it
     mergedModel = deepcopy(modelA)
 
@@ -346,12 +350,13 @@ route("/api/models/:model_id/model-composition", method = POST) do
 
         # Merge names, remove name from modelB
         mergedModel["S"][ID["modelA"]]["sname"] = string(nameToMergeA, nameToMergeB)
+        splice!(modelA["S"], ID["modelA"]) #
         splice!(modelB["S"], ID["modelB"])
     end
 
     # Merge places, merge transitions
     append!(mergedModel["S"], modelB["S"])
-    append!(mergedModel["T"], modelB["T"])
+    append!(mergedModel["T"], modelB["T"])    
 
     #= Merge inputs and outputs =#
     # Get final IDs of model A to add to the IDs in model B

--- a/src/service.jl
+++ b/src/service.jl
@@ -325,7 +325,7 @@ route("/api/models/model-composition", method = POST) do
     end
 
     if length(data["statesToMerge"]) < 1
-        return JSON.json("Empty common states array")
+        return JSON.json("Empty statesToMerge array")
     end
 
     modelA::Dict{String, Array{Dict{String, Any}, 1}} = data["modelA"]
@@ -343,7 +343,7 @@ route("/api/models/model-composition", method = POST) do
         # Loop through states to merge
         for i in 1:length(statesToMerge) 
             if !haskey(statesToMerge[i], modelName)
-                return JSON.json("Common state is missing model name: $modelName")
+                return JSON.json("statesToMerge array is missing model name: $modelName")
             end
             stateIsFound = false
             # Loop through model state names
@@ -361,7 +361,7 @@ route("/api/models/model-composition", method = POST) do
                 end
             end
             if !stateIsFound
-                return JSON.json("Common state label '$stateNameToMerge' is not found in $modelName")
+                return JSON.json("statesToMerge label '$stateNameToMerge' is not found in $modelName")
             end
         end
     end

--- a/src/service.jl
+++ b/src/service.jl
@@ -346,9 +346,9 @@ route("/api/models/model-composition", method = POST) do
                 return JSON.json("statesToMerge array is missing model name: $modelName")
             end
             stateIsFound = false
+            stateNameToMerge = statesToMerge[i][modelName]
             # Loop through model state names
             for j in 1:length(data[modelName]["S"]) 
-                stateNameToMerge = statesToMerge[i][modelName]
                 modelStateName = data[modelName]["S"][j]["sname"]
                 # Save ID of model state name which is going to be merged
                 if stateNameToMerge == modelStateName 


### PR DESCRIPTION
This combines two petri nets based on a list of common states.

In order to test this function you must checkout the [`stub-model-composition` branch](https://github.com/DARPA-ASKEM/TERArium/tree/stub-model-composition) from TERArium. This has the function `mergePetrinets` which passes some dummy petri net data to this service.  Press the "Merge petrinets" button to use it. 

Details about `mergePetrinets`:

`modelA` and `modelB` are the petrinets to be merged. `modelC` is the expected result of the merged petri nets based on the `statesToMerge` list. There is another `statesToMerge` list that you can test as well - you just have to comment it out. The result of this longer `statesToMerge` list corresponds to `modelC2` which is commented out as well.

Comparing the expected result to the merged one could be a bit confusing. The order of `is` and `it` change for example:
![Screenshot 2022-11-15 at 5 51 19 PM](https://user-images.githubusercontent.com/28237258/202047288-141814d8-a820-4426-9d0e-a94dd9da7514.png)

The order of elements could vary a bit too but that doesn't effect what the data means.