### PR TITLE
fix: prepare removal of modelB names properly

### DIFF
--- a/src/service.jl
+++ b/src/service.jl
@@ -375,9 +375,9 @@ route("/api/models/model-composition", method = POST) do
 
         # Merge names, plan to remove name from modelB
         mergedModel["S"][IDsToMerge["modelA"][i]]["sname"] = string(nameToMergeA, nameToMergeB)
-        modelB["S"][IDsToMerge["modelB"][i]] = Dict("sname" => 0) # Replace index which holds sname with 0
+        modelB["S"][IDsToMerge["modelB"][i]]["sname"] = nothing # Replace index which holds sname with nothing
     end
-    deleteat!(modelB["S"], findall(i -> i == Dict("sname" => 0), modelB["S"])) # Remove names that were merged from modelB
+    deleteat!(modelB["S"], findall(i -> i == Dict("sname" => nothing), modelB["S"])) # Remove names that were merged from modelB
 
     append!(mergedModel["S"], modelB["S"]) # Append the rest of the modelB state names that don't merge with modelA states
     append!(mergedModel["T"], modelB["T"]) # Append modelB transitions to modelA

--- a/src/service.jl
+++ b/src/service.jl
@@ -373,10 +373,11 @@ route("/api/models/model-composition", method = POST) do
         nameToMergeA = mergedModel["S"][IDsToMerge["modelA"][i]]["sname"]
         nameToMergeB = modelB["S"][IDsToMerge["modelB"][i]]["sname"]
 
-        # Merge names, remove name from modelB
+        # Merge names, plan to remove name from modelB
         mergedModel["S"][IDsToMerge["modelA"][i]]["sname"] = string(nameToMergeA, nameToMergeB)
-        splice!(modelB["S"], IDsToMerge["modelB"][i])
+        modelB["S"][IDsToMerge["modelB"][i]] = Dict("sname" => 0) # Replace index which holds sname with 0
     end
+    deleteat!(modelB["S"], findall(i -> i == Dict("sname" => 0), modelB["S"])) # Remove names that were merged from modelB
 
     append!(mergedModel["S"], modelB["S"]) # Append the rest of the modelB state names that don't merge with modelA states
     append!(mergedModel["T"], modelB["T"]) # Append modelB transitions to modelA


### PR DESCRIPTION
Before I removed the modelB names by matching an ID that will be merged and the index of the name, but I didn't think of the case where an index may not exist due to a previous deletion. This method of removing modelB names fixes this issue.